### PR TITLE
Limit external hosts to those configured

### DIFF
--- a/additional_imap.php
+++ b/additional_imap.php
@@ -437,6 +437,8 @@ class additional_imap extends rcube_plugin
                             $I = $V['delimiter'];
                             $q = 'readonly';
                         }
+                    } else if ($rcmail->config->get('additional_imap_limit_hosts', false)) {
+                        return;
                     } else {
                         $C = 'SELECT * FROM ' . rcmail::get_instance()->db->table_name('additional_imap_hosts').
                         ' WHERE domain=?';

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -106,6 +106,9 @@ $config['additional_imap_external'] = array(
 /* auto-detect IMAP server */
 $config['additional_imap_autodetect'] = true;
 
+/* Limit IMAP servers to those configured in 'additional_imap_external' */
+$config['additional_imap_limit_hosts'] = false;
+
 /* Cache remote accounts
    NOTE: if you enable this option your database user must have permissions to CREATE and DROP database tables */
 $config['additional_imap_cache'] = false;


### PR DESCRIPTION
Add setting `additional_imap_limit_hosts` to limit domains to those configured in `additional_imap_external`.

When set to `true` and the identity e-mail domain is not configured, the IMAP form will not be displayed.

Defaults to `false`.

Closes #4