### PR TITLE
Add additional_imap_limit_users setting

### DIFF
--- a/additional_imap.php
+++ b/additional_imap.php
@@ -7,6 +7,12 @@ class additional_imap extends rcube_plugin
     function init() {
         $this->rcmail = rcmail::get_instance();
         $this->load_config();
+
+        $limit_users = $this->rcmail->config->get('additional_imap_limit_users', false);
+        if (is_array($limit_users) && !in_array($this->rcmail->user->data['username'], $limit_users)) {
+            return;
+        }
+
         $this->register_action('plugin.additional_imap', array($this, 'switch_account'));
         $this->register_action('plugin.additional_imap_uninstall', array($this, 'uninstall'));
         $this->add_hook('startup', array($this, 'startup'));

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -106,6 +106,9 @@ $config['additional_imap_external'] = array(
 /* auto-detect IMAP server */
 $config['additional_imap_autodetect'] = true;
 
+/* Limit plugin access to those configured here. Accepts an array with usernames. */
+$config['additional_imap_limit_users'] = false;
+
 /* Cache remote accounts
    NOTE: if you enable this option your database user must have permissions to CREATE and DROP database tables */
 $config['additional_imap_cache'] = false;


### PR DESCRIPTION
Optional username whitelist. When the username is not in the array the plugin functions will not be loaded.

```php
$config['additional_imap_limit_users'] = array(
  'user1@domain.com',
  'user2@domain.com',
);
```

Defaults to `false` (disabled).

At first I tried to use the 'user_config' plugin to conditionally load the plugin based on usernames, but RC doesn't work that way or at least not anymore.